### PR TITLE
feat: allow shared lock to be obtained when there is reserved

### DIFF
--- a/sqlite_memory_vfs.py
+++ b/sqlite_memory_vfs.py
@@ -125,13 +125,7 @@ class MemoryVFSFile():
             if level == apsw.SQLITE_LOCK_EXCLUSIVE and self._locks[apsw.SQLITE_LOCK_SHARED] > 1:
                 raise apsw.BusyError()
 
-            if level == apsw.SQLITE_LOCK_SHARED:
-                self._locks[apsw.SQLITE_LOCK_SHARED] += 1
-            if level == apsw.SQLITE_LOCK_RESERVED:
-                self._locks[apsw.SQLITE_LOCK_RESERVED] += 1
-            if level == apsw.SQLITE_LOCK_EXCLUSIVE:
-                self._locks[ apsw.SQLITE_LOCK_EXCLUSIVE] += 1
-
+            self._locks[level] += 1
             self._level = level
 
     def xUnlock(self, level):

--- a/sqlite_memory_vfs.py
+++ b/sqlite_memory_vfs.py
@@ -133,12 +133,9 @@ class MemoryVFSFile():
             if self._level == level:
                 return
 
-            if self._level >= apsw.SQLITE_LOCK_EXCLUSIVE and level < apsw.SQLITE_LOCK_EXCLUSIVE:
-                self._locks[ apsw.SQLITE_LOCK_EXCLUSIVE] -= 1
-            if self._level >= apsw.SQLITE_LOCK_RESERVED and level < apsw.SQLITE_LOCK_RESERVED:
-                self._locks[apsw.SQLITE_LOCK_RESERVED] -= 1
-            if self._level >= apsw.SQLITE_LOCK_SHARED and level < apsw.SQLITE_LOCK_SHARED:
-                self._locks[apsw.SQLITE_LOCK_SHARED] -= 1
+            for lock_level in self._locks:
+                if self._level >= lock_level and level < lock_level:
+                    self._locks[lock_level] -= 1
 
             self._level = level
 

--- a/sqlite_memory_vfs.py
+++ b/sqlite_memory_vfs.py
@@ -133,7 +133,7 @@ class MemoryVFSFile():
             if self._level == level:
                 return
 
-            if self._level == apsw.SQLITE_LOCK_EXCLUSIVE and level < apsw.SQLITE_LOCK_EXCLUSIVE:
+            if self._level >= apsw.SQLITE_LOCK_EXCLUSIVE and level < apsw.SQLITE_LOCK_EXCLUSIVE:
                 self._locks[ apsw.SQLITE_LOCK_EXCLUSIVE] -= 1
             if self._level >= apsw.SQLITE_LOCK_RESERVED and level < apsw.SQLITE_LOCK_RESERVED:
                 self._locks[apsw.SQLITE_LOCK_RESERVED] -= 1


### PR DESCRIPTION
The previous version was a bit too strict in what was forbidden. It should be fine for shared locks to be obtained if another connection has a reserved lock.